### PR TITLE
Use absoluteUrl method on page instead of Url

### DIFF
--- a/RedirectToChild/RedirectToChildTags.php
+++ b/RedirectToChild/RedirectToChildTags.php
@@ -28,7 +28,7 @@ class RedirectToChildTags extends Tags
         $include_entries = false;
         $exclude         = '';
         $tree            = Content::tree($from, $max_depth, null, null, $exclude, Config::getShortLocale());
-        $url             = !empty($tree) ? $tree[0]['page']->url() : '';
+        $url             = !empty($tree) ? $tree[0]['page']->absoluteUrl() : '';
         $e               = new RedirectException;
 
         if (!empty($url)){


### PR DESCRIPTION
Temporarily fixes the issue that forces the system to redirect wrong locale url like /en/en 

https://github.com/statamic/v2-hub/issues/2303